### PR TITLE
Add one way flight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ swa \
   --interval 5 # In minutes (optional)
 ```
 
+If you would like to look at flights going **one way** between two airports, you can use the `--one-way` flag. This ignores values entered with `--return-date` and `--return-time`, and `--total-deal-price`.
+
+```bash
+swa \
+  --one-way
+  --from 'DAL' \
+  --to 'LGA' \
+  --leave-date '11/01/2017' \
+  --leave-time anytime \ # Can be anytime, morning, afternoon, evening (optional)
+  --fare-type 'dollars' \ # Can be dollars or points (optional)
+  --passengers 2 \
+  --individual-deal-price 50 \ # In dollars or points (optional)
+  --interval 5 # In minutes (optional)
+```
+
 ### Twilio integration
 If you have a Twilio account (I'm using a free trial account) and you've set up
 a deal price threshold, you can set the following environment vars to set up SMS
@@ -66,7 +81,7 @@ command, make sure you are running a version of node that supports ES6
 syntax (5.11.0 and up).
 
 ### C++11 compiler requirement
-You may experience compilation errors when you attempt to run `npm link`.  If so, 
+You may experience compilation errors when you attempt to run `npm link`.  If so,
 you'll need to make sure you have a C++11 compiler installed on your system.
 If you're running on Windows this is sometimes resolved by installing the [Visual C++
 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools).  For \*nix

--- a/index.js
+++ b/index.js
@@ -587,11 +587,11 @@ const settings  = {
   },
   individualDealPrice: {
     displayString: `Individual deal price: ${individualDealPrice ? `<= ${formatPrice(individualDealPrice)}` : "disabled"}`,
-    isValidOneWay: false,
+    isValidOneWay: true,
   },
   totalDealPrice: {
     displayString: `Total deal price: ${totalDealPrice ? `<= ${formatPrice(totalDealPrice)}` : "disabled"}`,
-    isValidOneWay: true,
+    isValidOneWay: false,
   },
   smsAlerts: {
     displayString: `SMS alerts: ${isTwilioConfigured ? process.env.TWILIO_PHONE_TO : "disabled"}`,

--- a/index.js
+++ b/index.js
@@ -418,23 +418,24 @@ const parsePriceMarkup = (priceMarkup) => {
  */
 const fetch = () => {
   const formData = {
-    twoWayTrip: (!isOneWay),
-    airTranRedirect: "",
-    returnAirport: (isOneWay ? "" : "RoundTrip"),
-    outboundTimeOfDay,
-    returnTimeOfDay,
-    seniorPassengerCount: 0,
-    fareType,
-    originAirport,
-    destinationAirport,
-    outboundDateString,
-    returnDateString,
-    adultPassengerCount
   }
 
   osmosis
     .get("https://www.southwest.com")
-    .submit(".booking-form--form",formData)
+    .submit(".booking-form--form", {
+      twoWayTrip: !isOneWay,
+      airTranRedirect: "",
+      returnAirport: isOneWay ? "" : "RoundTrip",
+      outboundTimeOfDay,
+      returnTimeOfDay,
+      seniorPassengerCount: 0,
+      fareType,
+      originAirport,
+      destinationAirport,
+      outboundDateString,
+      returnDateString,
+      adultPassengerCount
+    }).
     .find("#faresOutbound .product_price")
     .then((priceMarkup) => {
       const price = parsePriceMarkup(priceMarkup)

--- a/index.js
+++ b/index.js
@@ -548,78 +548,20 @@ airports.forEach((airport) => {
   }
 })
 
-const settings  = {
-  originAirport: {
-    displayString: `Origin airport: ${originAirport}`,
-    isValidOneWay: true,
-  },
-  destinationAirport: {
-    displayString: `Destination airport: ${destinationAirport}`,
-    isValidOneWay: true,
-  },
-  outboundDate: {
-    displayString: `Outbound date: ${outboundDateString}`,
-    isValidOneWay: true,
-  },
-  outboundTime: {
-    displayString: `Outbound time: ${outboundTimeOfDay}`,
-    isValidOneWay: true,
-  },
-  returnDate: {
-    displayString: `Return date: ${returnDateString}`,
-    isValidOneWay: false,
-  },
-  returnTime: {
-    displayString: `Return time: ${returnTimeOfDay}`,
-    isValidOneWay: false,
-  },
-  fareType: {
-    displayString: `Fare type: ${fareType}`,
-    isValidOneWay: true,
-  },
-  passengers: {
-    displayString: `Passengers: ${adultPassengerCount}`,
-    isValidOneWay: true,
-  },
-  interval: {
-    displayString: `Interval: ${pretty(interval * TIME_MIN)}`,
-    isValidOneWay: true,
-  },
-  individualDealPrice: {
-    displayString: `Individual deal price: ${individualDealPrice ? `<= ${formatPrice(individualDealPrice)}` : "disabled"}`,
-    isValidOneWay: true,
-  },
-  totalDealPrice: {
-    displayString: `Total deal price: ${totalDealPrice ? `<= ${formatPrice(totalDealPrice)}` : "disabled"}`,
-    isValidOneWay: false,
-  },
-  smsAlerts: {
-    displayString: `SMS alerts: ${isTwilioConfigured ? process.env.TWILIO_PHONE_TO : "disabled"}`,
-    isValidOneWay: true,
-  }
-}
-
-// If --one-way is enabled, only display values in the Settings widget that are relevant
-// to a one-way trip.
-const getValidSettingsStrings = (settings) => {
-  const settingsStrings = []
-
-  for (const s in settings) {
-    if (isOneWay) {
-      if (settings[s].isValidOneWay) {
-        settingsStrings.push(settings[s].displayString)
-      }
-    }
-    else {
-      settingsStrings.push(settings[s].displayString)
-    }
-  }
-
-  return settingsStrings
-}
-
-// Print settings
-dashboard.settings(getValidSettingsStrings(settings))
+dashboard.settings([
+  `Origin airport: ${originAirport}`,
+  `Destination airport: ${destinationAirport}`,
+  `Outbound date: ${outboundDateString}`,
+  `Outbound time: ${outboundTimeOfDay}`,
+  !isOneWay && `Return date: ${returnDateString}`,
+  !isOneWay && `Return time: ${returnTimeOfDay}`,
+  `Fare type: ${fareType}`,
+  `Passengers: ${adultPassengerCount}`,
+  `Interval: ${pretty(interval * TIME_MIN)}`,
+  !isOneWay && `Individual deal price: ${individualDealPrice ? `<= ${formatPrice(individualDealPrice)}` : "disabled"}`,
+  `Total deal price: ${totalDealPrice ? `<= ${formatPrice(totalDealPrice)}` : "disabled"}`,
+  `SMS alerts: ${isTwilioConfigured ? process.env.TWILIO_PHONE_TO : "disabled"}`
+].filter(s => s))
 
 fetch()
 

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ class Dashboard {
 
     // Graph return flight if one-way is not selected
     if (!isOneWay) {
-      this.grpahs.return = {
+      this.graphs.return = {
         title: "Destination/Return",
         x: [],
         y: [],


### PR DESCRIPTION
Southwest provides and displays one-way flights, so should we. This
commit adds support for the `--one-way` flag which changes the form
submission to only include single flights between two airports.

The flag removes conflicting options added by other flags such as
`--return-date` in order to prevent errors and incorrect form
submissions.

This feature closes #23 and produces valid data (could use some
testing).

Also in the commit is a documentation (comments) for #24 (closes #24) which notes
that there is an implicit use of a blessed widget method through
contrib inheriting blessed > List.

---

Below are some screenshots of the dashboard UI after adding support for `--one-way` which removes text/data related to return dates/flights.

Note:

**Settings**: Removed `Return Date`, `Return Time`, and `Total Deal Price`.

**Graph**: Removed `Return Flight`

**Log**: Only posting `Outbound Flight` prices.

![2017-01-14-9h-49m-59s](https://cloud.githubusercontent.com/assets/5200812/21959898/b8dc4e6a-daa3-11e6-80de-803deb9e467a.png)
