### PR TITLE
Add support for outbound/return date validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -624,7 +624,7 @@ const fetch = () => {
 
       dashboard.render()
 
-      // We don't want to to continue to refetch flight prices if non exist.
+      // We don't want to to continue to refetch flight prices if none exist.
       // Clear the timeout interval
       if (!datesAreValid) {
         setTimeout(fetch, interval * TIME_MIN)

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ const checkIfPastDates = () => {
   if (outboundDateString) {
     outboundDate = new Date(outboundDateString)
   } else {
-    throw new Error("Missing leave-date. If you don't know when you're leaving, how are you going to get anyhwere?")
+    throw new Error("Missing leave-date. If you don't know when you're leaving, how are you going to get anywhere?")
     process.exit(1);
   }
 
@@ -140,7 +140,7 @@ const checkIfPastDates = () => {
   }
 }
 
-// Validate immedaitely
+// Validate immediately
 checkIfPastDates()
 
 /**
@@ -481,7 +481,7 @@ const checkIfFutureDates = (lastDateString) => {
       if (returnDate.getYear() > lastBookableDate.getYear() ||
          (returnDate.getMonth() >= lastBookableDate.getMonth() && returnDate.getDay() > lastBookableDate.getDay())) {
         dashboard.log([
-          chalk.red(`Southwest doesn't have prices for flights after ${lastDateString}  -- You return date: ${returnDateString}`)
+          chalk.red(`Southwest doesn't have prices for flights after ${lastDateString}  -- Your return date: ${returnDateString}`)
         ])
         return false
       }
@@ -626,7 +626,7 @@ const fetch = () => {
 
       // We don't want to to continue to refetch flight prices if none exist.
       // Clear the timeout interval
-      if (!datesAreValid) {
+      if (datesAreValid) {
         setTimeout(fetch, interval * TIME_MIN)
       }
     })


### PR DESCRIPTION
This commit adds two functions for checking the valid starting - ending
dates for Southwest flights:

`checkIfPastDates`: Checks if either outbound or return are before the
durrent date (year, month, day - not hour)

`checkIfFutureDates`: First finds `#lastBookableDate` from the Southwest
website, then uses it to check if either outbound or return dates are
after the last bookable flight.

Checking for past dates is done immediately after command line args are
parsed. If they are invalid, and error is thrown.
Note: this could be handled better with a friendlier message to the
user.

Checking for future dates is done after the `#lastBookableDate` element
is found on southwest.com.
If there are invalid dates, it displays in the Log.
Note: The setInterval created by the waypoints casuses the message to be
added to the Log multiple times due to screen.render() being called.

Would appreciate any feedback!

Closes #7, #4 