### PR TITLE
Add support for international destinations

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,12 +435,12 @@ const fetch = () => {
       returnDateString,
       adultPassengerCount
     })
-    .find("#faresOutbound .product_price")
+    .find("#faresOutbound .product_price, #b0Table span.var.h5")
     .then((priceMarkup) => {
       const price = parsePriceMarkup(priceMarkup)
       fares.outbound.push(price)
     })
-    .find("#faresReturn .product_price")
+    .find("#faresReturn .product_price, #b1Table span.var.h5")
     .then((priceMarkup) => {
       if (isOneWay) return // Only record return prices if it's a two-way flight
       const price = parsePriceMarkup(priceMarkup)


### PR DESCRIPTION
This commit adds updates the selector used to find the outbound and return flight prices.

If a domestic city pair is selected, the fares page renders with
`#faresOutbound .product_price`
and
`#faresReturn .product_price`

If one or both of the cities is outside the US, the page renders with
`#b0Table span.var.h5`
and
`#b1Table span.var.h5`

The page never renders with both sets of attrs, so using a multiple selector should be safe.

