### PR TITLE
Corrects issue with deal reporting if one way.

### DIFF
--- a/index.js
+++ b/index.js
@@ -590,8 +590,8 @@ dashboard.settings([
   `Fare type: ${fareType.toLowerCase()}`,
   `Passengers: ${adultPassengerCount}`,
   `Interval: ${pretty(interval * TIME_MIN)}`,
-  !isOneWay && `Individual deal price: ${individualDealPrice ? `<= ${formatPrice(individualDealPrice)}` : "disabled"}`,
-  `Total deal price: ${totalDealPrice ? `<= ${formatPrice(totalDealPrice)}` : "disabled"}`,
+  isOneWay && `Individual deal price: ${individualDealPrice ? `<= ${formatPrice(individualDealPrice)}` : "disabled"}`,
+  !isOneWay && `Total deal price: ${totalDealPrice ? `<= ${formatPrice(totalDealPrice)}` : "disabled"}`,
   `SMS alerts: ${isTwilioConfigured ? process.env.TWILIO_PHONE_TO : "disabled"}`,
   `Daily update: ${dailyUpdate ? dailyUpdateAt : "disabled"}`
 ].filter(s => s))


### PR DESCRIPTION
The logic for `individual deal price` and `total deal price` seemed a bit backwards, for reporting on the screen.

If the `isOneWay` arg is added, the only visible option should be individual deal price, rather than total deal price. I've added operations to show either one or the other.